### PR TITLE
Fix tab label text appearing on pinned tab.

### DIFF
--- a/userChrome-dark.css
+++ b/userChrome-dark.css
@@ -12,6 +12,11 @@
   margin-top: 2px !important;
 }
 
+/* To prevent tab label appearing on pinned tab in compact mode. */
+.tab-content {
+  padding: 0 12px !important;
+}
+
 /* When the window is maximized, the first pinned tab is properly displayed. */
 #TabsToolbar  {
   padding-inline-start: 15px !important;

--- a/userChrome-default.css
+++ b/userChrome-default.css
@@ -12,6 +12,11 @@
   margin-top: 2px !important;
 }
 
+/* To prevent tab label appearing on pinned tab in compact mode. */
+.tab-content {
+  padding: 0 12px !important;
+}
+
 /* When the window is maximized, the first pinned tab is properly displayed. */
 #TabsToolbar  {
   padding-inline-start: 15px !important;

--- a/userChrome-light.css
+++ b/userChrome-light.css
@@ -16,6 +16,11 @@
   margin-top: 2px !important;
 }
 
+/* To prevent tab label appearing on pinned tab in compact mode. */
+.tab-content {
+  padding: 0 12px !important;
+}
+
 /* When the window is maximized, the first pinned tab is properly displayed. */
 #TabsToolbar  {
   padding-inline-start: 15px !important;


### PR DESCRIPTION
Only happens for compact density, which I don't regularly
test against.